### PR TITLE
Inspector Variable Organization

### DIFF
--- a/MeltdownUnity/Assets/Credits.txt
+++ b/MeltdownUnity/Assets/Credits.txt
@@ -3,3 +3,5 @@ Credits
 
 Distant-explosion ----- Sound Effect ----- Pixabay
 Punch-like-a-Rock ----- Sound Effect ----- Pixabay
+
+[ShowOnly] attribute ----- Script ----- Lev-Lukomskyi (Unity Forums)

--- a/MeltdownUnity/Assets/Scripts/Managers/BoomEntrance/BoomEntrance.cs
+++ b/MeltdownUnity/Assets/Scripts/Managers/BoomEntrance/BoomEntrance.cs
@@ -26,12 +26,13 @@ public class BoomEntrance : MonoBehaviour
 
     [Header("<b>Shake Parameters (All in %)</b>")]
     [Space]
-    [SerializeField][Range(0f, 1000f)] private float _shakeSeconds = 180f;
-    [SerializeField][Range(0f, 1000f)] private float _shakeHorizontal = 80f;
-    [SerializeField][Range(0f, 1000f)] private float _shakeVertical = 150f;
+    [Tooltip("The duration of the shake in seconds.")][SerializeField][Range(0f, 1000f)] private float _shakeSeconds = 180f;
+    [Tooltip("The amount of horizontal shake.")][SerializeField][Range(0f, 1000f)] private float _shakeHorizontal = 80f;
+    [Tooltip("The amount of vertical shake.")][SerializeField][Range(0f, 1000f)] private float _shakeVertical = 150f;
 
     [Header("<b>Audio Parameters (All in %)</b>")]
     [Space]
+    [Tooltip("The audio tracks to be played.")]
     [SerializeField] private AudioVariables[] _audioTracks =
     {
         new AudioVariables { name = "Track 1", audioClip = null, pitch = 300f, volume = 70f },
@@ -40,9 +41,9 @@ public class BoomEntrance : MonoBehaviour
 
     [Header("<b>Action Paramaters</b>")]
     [Space]
-    public bool PlayShakeAndClips = false;
-    public bool Shake = false;
-    public bool PlayClips = false;
+    [Tooltip("Play both the shake and the audio clips.")] public bool PlayShakeAndClips = false;
+    [Tooltip("Play the shake.")] public bool Shake = false;
+    [Tooltip("Play the audio clips.")] public bool PlayClips = false;
 
 
     // [Events]

--- a/MeltdownUnity/Assets/Scripts/Mods.meta
+++ b/MeltdownUnity/Assets/Scripts/Mods.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbe9664524e251b459e4a11dec21ffea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MeltdownUnity/Assets/Scripts/Mods/ShowOnlyAttribute.cs
+++ b/MeltdownUnity/Assets/Scripts/Mods/ShowOnlyAttribute.cs
@@ -1,0 +1,38 @@
+// Credit: Lev-Lukomskyi (Unity Forums)
+
+using UnityEngine;
+using UnityEditor;
+
+public class ShowOnlyAttribute : PropertyAttribute
+{
+}
+
+[CustomPropertyDrawer(typeof(ShowOnlyAttribute))]
+public class ShowOnlyDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty prop, GUIContent label)
+    {
+        string valueStr;
+
+        switch (prop.propertyType)
+        {
+            case SerializedPropertyType.Integer:
+                valueStr = prop.intValue.ToString();
+                break;
+            case SerializedPropertyType.Boolean:
+                valueStr = prop.boolValue.ToString();
+                break;
+            case SerializedPropertyType.Float:
+                valueStr = prop.floatValue.ToString("0.0");
+                break;
+            case SerializedPropertyType.String:
+                valueStr = prop.stringValue;
+                break;
+            default:
+                valueStr = "(not supported)";
+                break;
+        }
+
+        EditorGUI.LabelField(position, label.text, valueStr);
+    }
+}

--- a/MeltdownUnity/Assets/Scripts/Mods/ShowOnlyAttribute.cs.meta
+++ b/MeltdownUnity/Assets/Scripts/Mods/ShowOnlyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0eaad2ffd86f8849a180a3cadc6e23a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Sliding Circular Door/SlidingCircularDoor.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Sliding Circular Door/SlidingCircularDoor.cs
@@ -14,10 +14,9 @@ public class SlidingCircularDoor : MonoBehaviour
 
     [Header("<b>Door Parameters</b>")]
     [Space]
-    [SerializeField][Range(0.0f, 10.0f)] private float _openDistance = 0.6f;
-    [SerializeField][Range(0.0f, 10.0f)] private float _doorSpeed = 0.7f;
-
-    public bool openDoor = false;
+    [Tooltip("The distance the door opens.")][SerializeField][Range(0.0f, 10.0f)] private float _openDistance = 0.6f;
+    [Tooltip("The speed the door opens.")][SerializeField][Range(0.0f, 10.0f)] private float _doorSpeed = 0.7f;
+    [Tooltip("Whether the door is open.")] public bool openDoor = false;
 
     // [Events]
 

--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
@@ -771,8 +771,13 @@ public class GaugeIndicator : MonoBehaviour
 
     private void SetDisabled()
     {
+        // Sets fire and ice calls to 0 to halt recursion, then sets to original number after a delay.
         _fireCalls = 0;
         _iceCalls = 0;
+        Invoke("SetFireCalls", _smallDelay);
+        Invoke("SetIceCalls", _smallDelay);
+
+        // Disables movement.
         MoveToNextPoint = false;
         MoveToPrevPoint = false;
         AutoCoolOn = false;

--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
@@ -32,54 +32,54 @@ public class GaugeIndicator : MonoBehaviour
 
     [Header("<size=15>Rotation Parameters</size>")]
     [Space]
-    [SerializeField] private Vector3 _rotationAxis = Vector3.back;
-    [SerializeField][Range(0.0f, 360.0f)] private float _minDegreesBelowStart = 90.0f;
-    [Range(0, 100)] public int _firePercentage = 40;
-    [Range(0, 100)] public int _icePercentage = 20;
-    [SerializeField][Range(19.9f, 360.0f)] private float _maxDegrees = 180.0f;
-    [SerializeField][Range(0.0f, 100.0f)] private float _heatingSpeed = 40.0f;
-    [SerializeField][Range(0.0f, 100.0f)] private float _coolingSpeed = 40.0f;
+    [Tooltip("The axis of rotation in x, y, z.")][SerializeField] private Vector3 _rotationAxis = Vector3.back;
+    [Tooltip("The degrees before the start where the minimum point is.")][SerializeField][Range(0.0f, 360.0f)] private float _minDegreesBelowStart = 90.0f;
+    [Tooltip("The progression a fire hit does in the dual fire-ice scale.")][Range(0, 100)] public int _firePercentage = 40;
+    [Tooltip("The regression an ice hit does in the dual fire-ice scale.")][Range(0, 100)] public int _icePercentage = 20;
+    [Tooltip("The size of a dual fire-ice scale. 19.9 is off.")][SerializeField][Range(19.9f, 360.0f)] private float _maxDegrees = 180.0f;
+    [Tooltip("The speed of a fire hit.")][SerializeField][Range(0.0f, 100.0f)] private float _heatingSpeed = 40.0f;
+    [Tooltip("The speed of an ice hit.")][SerializeField][Range(0.0f, 100.0f)] private float _coolingSpeed = 40.0f;
 
     [Header("<size=15>Location Parameters</size>")]
     [Space]
+    [Tooltip("The destination range at which events occur.")]
     [SerializeField]
     public Destination[] _destinations =
     {
         new Destination { name = "On", minPosition = 0.0f, maxPosition = 0.0f},
     };
-    public bool MoveToNextPoint = false;
-    public bool MoveToPrevPoint = false;
-    public bool ResetPinLocation = false;
-    public bool FinalPinLocation = false;
+    [Tooltip("Moves according to one fire hit.")] public bool MoveToNextPoint = false;
+    [Tooltip("Moves according to one ice hit.")] public bool MoveToPrevPoint = false;
+    [Tooltip("Resets to the start position.")] public bool ResetPinLocation = false;
+    [Tooltip("Moves to the final position.")] public bool FinalPinLocation = false;
+    [Tooltip("Moves to the minimum position.")] public bool MinLocation = false;
 
     [Header("<size=14>Test-Only Rotation Parameters</size>")]
     [Space]
-    [SerializeField] private float[] _heatRotationPoints = { 0.0f, 70f, 140.0f, 210.0f };
-    [SerializeField] private float[] _coolRotationPoints = { 0.0f, 35.0f, 70.0f, 105.0f, 140.0f, 175.0f, 210.0f };
-    [SerializeField][Range(0, 50)] private int _equalHeatPoints = 3;
-    [SerializeField][Range(10.0f, 360.0f)] private float _equalHeatEndPoint = 210.0f;
+    [Tooltip("The fire rotation points.")][SerializeField] private float[] _heatRotationPoints = { 0.0f, 70f, 140.0f, 210.0f };
+    [Tooltip("The ice rotation points.")][SerializeField] private float[] _coolRotationPoints = { 0.0f, 35.0f, 70.0f, 105.0f, 140.0f, 175.0f, 210.0f };
+    [Tooltip("The equidistant number of fire rotation points.")][SerializeField][Range(0, 50)] private int _equalHeatPoints = 3;
+    [Tooltip("The size of the fire scale.")][SerializeField][Range(10.0f, 360.0f)] private float _equalHeatEndPoint = 210.0f;
     [Space]
-    [SerializeField][Range(0, 50)] private int _equalCoolPoints = 7;
-    [SerializeField][Range(10.0f, 360.0f)] private float _equalCoolEndPoint = 210.0f;
+    [Tooltip("The equidistant number of ice rotation points.")][SerializeField][Range(0, 50)] private int _equalCoolPoints = 7;
+    [Tooltip("The size of the ice scale.")][SerializeField][Range(10.0f, 360.0f)] private float _equalCoolEndPoint = 210.0f;
     [Space]
-    [SerializeField][Range(0.0f, 100.0f)] private float _autoCoolDelay = 2.0f;
-    public bool AutoCoolOn = false;
-    public bool AutoCoolTriggerOn = false;
-    public bool InstantRotation = false;
-    public bool RunTimeReposition = false;
-    public bool HeatOnlyScale = false;
-    [Range(0, 50)] public int FireCalls = 1;
-    [Range(0, 50)] public int IceCalls = 1;
+    [Tooltip("The delay at which auto-cooling begins.")][SerializeField][Range(0.0f, 100.0f)] private float _autoCoolDelay = 2.0f;
+    [Tooltip("Whether auto-cooling is active.")] public bool AutoCoolOn = false;
+    [Tooltip("Whether auto-cooling is triggered.")] public bool AutoCoolTriggerOn = false;
+    [Tooltip("Whether instant movement is on.")] public bool InstantRotation = false;
+    [Tooltip("Whether the rotation points adapat at run-time (currently heat-only).")] public bool RunTimeReposition = false;
+    [Tooltip("Makes the ice hits the same as fire hits.")] public bool HeatOnlyScale = false;
+    [Tooltip("The number of fire hits.")][Range(0, 50)] public int FireCalls = 1;
+    [Tooltip("The number of ice hits.")][Range(0, 50)] public int IceCalls = 1;
 
     [Header("<size=14>Test-Only Location Parameters </size>")]
     [Space]
-    [SerializeField] private bool _setStartPosition = false;
-    [SerializeField] private Vector3 _startPosition = Vector3.zero;
+    [Tooltip("Whether setting the local start position is enabled.")][SerializeField] private bool _setStartPosition = false;
+    [Tooltip("The co-ordinates to set the local start position.")][SerializeField] private Vector3 _startPosition = Vector3.zero;
     [Space]
-    [SerializeField] private bool _setStartRotation = false;
-    [SerializeField] private Vector3 _startRotation = Vector3.zero;
-    [Space]
-    [SerializeField] private bool _minLocation = false;
+    [Tooltip("Whether setting the local start rotation is enabled.")][SerializeField] private bool _setStartRotation = false;
+    [Tooltip("The co-ordinates to set the local start rotation.")][SerializeField] private Vector3 _startRotation = Vector3.zero;
 
     public UnityEvent<string> OnComplete;
 
@@ -147,9 +147,9 @@ public class GaugeIndicator : MonoBehaviour
             FinalPinLocation = false;
             MaxGauge();
         }
-        else if (_minLocation)
+        else if (MinLocation)
         {
-            _minLocation = false;
+            MinLocation = false;
             if (!HeatOnlyScale)
             {
                 MinGauge();


### PR DESCRIPTION
## Changelog

* Added inspector variable tooltips to every one of the scripts I created.
* Ongoing re-organization of gauge script variables.
* Added [ShowOnly] attribute script for inspector variables. This allows you to display values in the inspector that can't be changed.  I displayed central position and tolerance variables, which are calculated from minPosition and maxPosition in the destinations. The destinations are what trigger  subsequent events.