### PR TITLE
Gauge Script: Editor Variables & Bug Fixing

### DIFF
--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
@@ -157,6 +157,7 @@ public class GaugeIndicator : MonoBehaviour
 		_finalCoolPoint = _coolRotationPoints[_finalCoolIndex];
 		_nextRotationPoint = _heatRotationPoints[_heatIndex];
 		_prevRotationPoint = !HeatOnlyScale ? _firstCoolPoint : _firstHeatPoint;
+		_rotationIncrement = _heatRotationPoints[_initialHeatIndex];
 
         // Sets Number of Calls to Repeat
         SetFireCalls();
@@ -452,10 +453,23 @@ public class GaugeIndicator : MonoBehaviour
 
 	private int GetInitialIndex()
 	{
-		for (int i = _firstHeatIndex; i < _heatRotationPoints.Length; i++)
+		float approxStartingPoint = _heatRotationPoints[_firstHeatIndex] + _minDegreesBelowStart;
+
+        for (int i = _firstHeatIndex; i < _heatRotationPoints.Length; i++)
 		{
-			if (Mathf.Round(_heatRotationPoints[i]) == (_heatRotationPoints[_firstHeatIndex] + _minDegreesBelowStart))
+			// Finds a rotation point near the min degrees below.
+			if (_heatRotationPoints[i] >= approxStartingPoint)
 			{
+                // checks which point is closer if there's a previous point.
+                if (i > _firstHeatIndex)
+				{
+					float prevDif = Mathf.Abs(_heatRotationPoints[i-1] - approxStartingPoint);
+					float curDif = Mathf.Abs(_heatRotationPoints[i] - approxStartingPoint);
+					if (prevDif < curDif)
+					{
+						return i - 1;
+					}
+                }
 				return i;
 			}
 		}
@@ -620,7 +634,7 @@ public class GaugeIndicator : MonoBehaviour
 			_coolIndex = FindCoolIndex(i);
 			_prevRotationPoint = _coolRotationPoints[_coolIndex];
 		}
-		else if (_didForwardRot || (_rotationIncrement == _firstHeatPoint && _rotationIncrement != _firstCoolPoint))
+		else if (_didForwardRot || (_rotationIncrement == _initialHeatPoint && _rotationIncrement != _firstCoolPoint))
 		{
 			_coolIndex = FindCoolIndex(i - 1);
 			_prevRotationPoint = _coolRotationPoints[_coolIndex];

--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
@@ -493,7 +493,8 @@ public class GaugeIndicator : MonoBehaviour
 		// Resets tracking-related variables
 		_rotationIncrement = _initialHeatPoint;
 		_heatIndex = _startHeatIndex;
-		SetRotationPoints(_heatIndex, _coolIndex);
+        _coolIndex = FindCoolIndex(_heatIndex);
+        SetRotationPoints(_heatIndex, _coolIndex);
         Invoke("SetFireCalls", _smallDelay);
         Invoke("SetIceCalls", _smallDelay);
         MoveToNextPoint = false;

--- a/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
+++ b/MeltdownUnity/Assets/Scripts/Puzzle Elements/Steam Generator/GaugeIndicator.cs
@@ -73,8 +73,8 @@ public class GaugeIndicator : MonoBehaviour
 	[Tooltip("The set number of rotation points to go through by ice.")][Range(0, 100)] public int IceCalls = 1;
 	[Tooltip("The remaining number of rotation points to go through by fire.")][SerializeField][Range(0, 100)] private int _remainingFireCalls;
 	[Tooltip("The remaining number of rotation points to go through by ice.")][SerializeField][Range(0, 100)] private int _remainingIceCalls;
-    [Tooltip("The next rotation point after heating repetition is done.")][SerializeField][ShowOnly] private float _nextStop;
     [Tooltip("The previous rotation point after cooling repetition is done.")][SerializeField][ShowOnly] private float _prevStop;
+    [Tooltip("The next rotation point after heating repetition is done.")][SerializeField][ShowOnly] private float _nextStop;
 
     [Header("<size=15>Scale Parameters</size>")]
 	[Space]
@@ -147,7 +147,6 @@ public class GaugeIndicator : MonoBehaviour
 		_finalHeatIndex = _heatRotationPoints.Length - 1;
 		_finalCoolIndex = _coolRotationPoints.Length - 1;
 		_heatIndex = _startHeatIndex;
-		_coolIndex = FindCoolIndex(_heatIndex);
 
 		// Elements of Array
 		_firstHeatPoint = _heatRotationPoints[_firstHeatIndex];
@@ -159,7 +158,10 @@ public class GaugeIndicator : MonoBehaviour
 		_prevRotationPoint = !HeatOnlyScale ? _firstCoolPoint : _firstHeatPoint;
 		_rotationIncrement = _heatRotationPoints[_initialHeatIndex];
 
-        // Sets Number of Calls to Repeat
+		// Prev/Current Rotation Points need to be known.
+        _coolIndex = FindCoolIndex(_heatIndex);
+
+        // Sets Number of Calls to Repeat.
         SetFireCalls();
         SetIceCalls();
 
@@ -306,7 +308,8 @@ public class GaugeIndicator : MonoBehaviour
 				else
 				{
 					Invoke("SetFireCalls", _smallDelay);
-				}
+                    Invoke("SetIceCalls", _smallDelay);
+                }
 			}
 		}
 	}
@@ -418,7 +421,8 @@ public class GaugeIndicator : MonoBehaviour
 				}
 				else
 				{
-					Invoke("SetIceCalls", _smallDelay);
+                    Invoke("SetFireCalls", _smallDelay);
+                    Invoke("SetIceCalls", _smallDelay);
                 }
 			}
 		}
@@ -490,7 +494,9 @@ public class GaugeIndicator : MonoBehaviour
 		_rotationIncrement = _initialHeatPoint;
 		_heatIndex = _startHeatIndex;
 		SetRotationPoints(_heatIndex, _coolIndex);
-		MoveToNextPoint = false;
+        Invoke("SetFireCalls", _smallDelay);
+        Invoke("SetIceCalls", _smallDelay);
+        MoveToNextPoint = false;
 		MoveToPrevPoint = false;
 		_didForwardRot = false;
 		_didBackRot = false;
@@ -511,7 +517,9 @@ public class GaugeIndicator : MonoBehaviour
 		_coolIndex = _startCoolIndex;
 		_heatIndex = _firstCoolPoint == _firstHeatPoint ? _secondHeatIndex : _firstHeatIndex;
 		SetRotationPoints(_heatIndex, _coolIndex);
-		MoveToNextPoint = false;
+        Invoke("SetFireCalls", _smallDelay);
+        Invoke("SetIceCalls", _smallDelay);
+        MoveToNextPoint = false;
 		MoveToPrevPoint = false;
 		_didForwardRot = false;
 		_didBackRot = false;
@@ -532,7 +540,9 @@ public class GaugeIndicator : MonoBehaviour
 		_rotationIncrement = _finalHeatPoint;
 		_heatIndex = _finalHeatIndex;
 		SetRotationPoints(_heatIndex, _coolIndex);
-		MoveToNextPoint = false;
+        Invoke("SetFireCalls", _smallDelay);
+        Invoke("SetIceCalls", _smallDelay);
+        MoveToNextPoint = false;
 		MoveToPrevPoint = false;
 		_didForwardRot = false;
 		_didBackRot = false;
@@ -609,7 +619,7 @@ public class GaugeIndicator : MonoBehaviour
 		}
 
 		// Permutations to set next rotation point.
-		if (HeatOnlyScale || _didForwardRot || _rotationIncrement == _firstCoolPoint || _rotationIncrement == _firstHeatPoint || _rotationIncrement == _finalHeatPoint)
+		if (HeatOnlyScale || _didForwardRot || _rotationIncrement == _firstCoolPoint ||  _rotationIncrement == _initialHeatPoint || _rotationIncrement == _finalHeatPoint)
 		{
 			_nextRotationPoint = _heatRotationPoints[i];
 		}
@@ -634,7 +644,7 @@ public class GaugeIndicator : MonoBehaviour
 			_coolIndex = FindCoolIndex(i);
 			_prevRotationPoint = _coolRotationPoints[_coolIndex];
 		}
-		else if (_didForwardRot || (_rotationIncrement == _initialHeatPoint && _rotationIncrement != _firstCoolPoint))
+		else if (_didForwardRot || (_rotationIncrement == _initialHeatPoint && _rotationIncrement != _firstCoolPoint && !_didBackRot))
 		{
 			_coolIndex = FindCoolIndex(i - 1);
 			_prevRotationPoint = _coolRotationPoints[_coolIndex];
@@ -704,7 +714,7 @@ public class GaugeIndicator : MonoBehaviour
 			}
 
 			noResult = false;
-		}
+        }
 
 		if (noResult)
 		{


### PR DESCRIPTION
## Changelog

### Added
* 2 Show-only variables for the inspector: _prevStop and _next Stop. They track the previous and next rotation points, but taking into account repetition.

### Fixed
* For when there's no 0 degree point, fixed it so that it founded a point closest to 0 for the min degrees below feature.
* Bugs associated with setting to Min, Default and Final Positions.